### PR TITLE
Maven server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains an [example app](https://github.com/mparticle-integrati
 
 [See a full build.gradle example here](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/blob/master/example/build.gradle)
 
-1. The Braze Kit requires that you add Braze's Maven server to your buildscript:
+1. The Braze Kit requires that you add Braze's Maven server to your allprojects:
 
     ```
     repositories {


### PR DESCRIPTION
Braze's doc indicates that the Maven server should be added to allprojects, and not buildscript.
https://www.braze.com/docs/developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration/#step-1-integrate-the-braze-library 
